### PR TITLE
Revise examples

### DIFF
--- a/example/SConscript
+++ b/example/SConscript
@@ -10,6 +10,7 @@ utils = env.Object(source='utils.cpp')
                      utils],
              LIBS=libs)
  for example in ['async_connect',
+                 'async_execute',
                  'async_multi_query',
                  'async_single_query',
                  'blocking_connect',

--- a/example/async_connect.cpp
+++ b/example/async_connect.cpp
@@ -15,14 +15,7 @@ global_options opts;
 void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Connection error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-        return;
-    }
-
+    check_error(ec);
     std::cout << "Connected." << std::endl;
 }
 

--- a/example/async_connect.cpp
+++ b/example/async_connect.cpp
@@ -1,5 +1,6 @@
 #include "utils.hpp"
 
+#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
@@ -25,13 +26,15 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    connector.async_connect(opts.tcp_endpoint(),
-                            opts.auth_info(),
-                            opts.schema,
-                            amy::default_flags,
-                            boost::bind(handle_connect,
-                                        amy::placeholders::error,
-                                        boost::ref(connector)));
+    using namespace amy::keyword;
+
+    amy::async_connect(_connector = connector,
+                       _endpoint  = opts.tcp_endpoint(),
+                       _auth      = opts.auth_info(),
+                       _database  = opts.schema,
+                       _handler   = boost::bind(handle_connect,
+                                                amy::placeholders::error,
+                                                boost::ref(connector)));
 
     io_service.run();
 

--- a/example/async_connect.cpp
+++ b/example/async_connect.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
@@ -33,15 +32,13 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::async_connect(_connector = connector,
-                       _endpoint  = opts.tcp_endpoint(),
-                       _auth      = opts.auth_info(),
-                       _database  = opts.schema,
-                       _handler   = boost::bind(handle_connect,
-                                                amy::placeholders::error,
-                                                boost::ref(connector)));
+    connector.async_connect(opts.tcp_endpoint(),
+                            opts.auth_info(),
+                            opts.schema,
+                            amy::default_flags,
+                            boost::bind(handle_connect,
+                                        amy::placeholders::error,
+                                        boost::ref(connector)));
 
     io_service.run();
 

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -1,0 +1,73 @@
+#include "utils.hpp"
+
+#include <amy/connector.hpp>
+#include <amy/execute.hpp>
+#include <amy/placeholders.hpp>
+
+#include <boost/asio/io_service.hpp>
+#include <boost/bind.hpp>
+#include <boost/format.hpp>
+#include <boost/system/system_error.hpp>
+
+#include <iostream>
+
+global_options opts;
+
+void handle_execute(boost::system::error_code const& ec,
+                    uint64_t affected_rows,
+                    amy::connector& connector)
+{
+    if (!!ec) {
+        std::cerr
+            << boost::format("Statement execution failed: %1% - %2%")
+               % ec.value() % ec.message()
+            << std::endl;
+        return;
+    }
+
+    std::cout
+        << boost::format("Affected rows: %1%") % affected_rows
+        << std::endl;
+
+    return;
+}
+
+void handle_connect(boost::system::error_code const& ec,
+                    amy::connector& connector)
+{
+    if (!!ec) {
+        std::cerr
+            << boost::format("Connection error: %1% - %2%")
+               % ec.value() % ec.message()
+            << std::endl;
+        return;
+    }
+
+    std::cout << "Connected" << std::endl;
+
+    amy::async_execute(connector,
+                       read_from_stdin(),
+                       boost::bind(handle_execute,
+                                   amy::placeholders::error,
+                                   amy::placeholders::affected_rows,
+                                   boost::ref(connector)));
+}
+
+int main(int argc, char* argv[]) {
+    parse_command_line_options(argc, argv);
+
+    boost::asio::io_service io_service;
+    amy::connector connector(io_service);
+
+    connector.async_connect(opts.tcp_endpoint(),
+                            opts.auth_info(),
+                            opts.schema,
+                            amy::default_flags,
+                            boost::bind(handle_connect,
+                                        amy::placeholders::error,
+                                        boost::ref(connector)));
+
+    io_service.run();
+
+    return 0;
+}

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -18,10 +18,7 @@ void handle_execute(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
-    std::cout
-        << boost::format("Affected rows: %1%") % affected_rows
-        << std::endl;
-
+    std::cout << "Affected rows: " << affected_rows << std::endl;
     return;
 }
 
@@ -29,8 +26,6 @@ void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
-    std::cout << "Connected" << std::endl;
-
     amy::async_execute(connector,
                        read_from_stdin(),
                        boost::bind(handle_execute,

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -17,14 +17,7 @@ void handle_execute(boost::system::error_code const& ec,
                     uint64_t affected_rows,
                     amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Statement execution failed: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-        return;
-    }
-
+    check_error(ec);
     std::cout
         << boost::format("Affected rows: %1%") % affected_rows
         << std::endl;
@@ -35,14 +28,7 @@ void handle_execute(boost::system::error_code const& ec,
 void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Connection error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-        return;
-    }
-
+    check_error(ec);
     std::cout << "Connected" << std::endl;
 
     amy::async_execute(connector,

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -26,6 +26,8 @@ void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
+
+    // Executes an arbitrary SQL statement read from stdin.
     amy::async_execute(connector,
                        read_from_stdin(),
                        boost::bind(handle_execute,

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
@@ -79,15 +78,13 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::async_connect(_connector = connector,
-                       _endpoint  = opts.tcp_endpoint(),
-                       _auth      = opts.auth_info(),
-                       _flags     = amy::client_multi_statements,
-                       _handler   = boost::bind(handle_connect,
-                                                amy::placeholders::error,
-                                                boost::ref(connector)));
+    connector.async_connect(opts.tcp_endpoint(),
+                            opts.auth_info(),
+                            opts.schema,
+                            amy::default_flags,
+                            boost::bind(handle_connect,
+                                        amy::placeholders::error,
+                                        boost::ref(connector)));
 
     io_service.run();
 

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) try {
     connector.async_connect(opts.tcp_endpoint(),
                             opts.auth_info(),
                             opts.schema,
-                            amy::default_flags,
+                            amy::client_multi_statements,
                             boost::bind(handle_connect,
                                         amy::placeholders::error,
                                         boost::ref(connector)));

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -13,13 +13,21 @@
 global_options opts;
 
 void handle_store_result(boost::system::error_code const& ec,
-                         amy::result_set result_set,
+                         amy::result_set rs,
                          amy::connector& connector)
 {
     check_error(ec);
 
+    // Prints result sets of each executed query.
+    std::cout
+        << boost::format("Affected rows: %1%, "
+                         "field count: %2%, "
+                         "result set size %3%")
+           % rs.affected_rows() % rs.field_count() % rs.size()
+        << std::endl;
+
     auto out = std::ostream_iterator<amy::row>(std::cout, "\n");
-    std::copy(result_set.begin(), result_set.end(), out);
+    std::copy(rs.begin(), rs.end(), out);
 
     if (connector.has_more_results()) {
         connector.async_store_result(
@@ -45,6 +53,8 @@ void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
+
+    // Executes multiple ';'-separated SQL queries read from stdin.
     connector.async_query(read_from_stdin(),
                           boost::bind(handle_query,
                                       amy::placeholders::error,

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -17,9 +17,9 @@ void handle_store_result(boost::system::error_code const& ec,
                          amy::connector& connector)
 {
     check_error(ec);
-    std::copy(result_set.begin(),
-              result_set.end(),
-              std::ostream_iterator<amy::row>(std::cout, "\n"));
+
+    auto out = std::ostream_iterator<amy::row>(std::cout, "\n");
+    std::copy(result_set.begin(), result_set.end(), out);
 
     if (connector.has_more_results()) {
         connector.async_store_result(
@@ -45,9 +45,6 @@ void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
-    std::cout << "Connected." << std::endl;
-
-    // Executes multiple ';'-separated SQL queries read from stdin
     connector.async_query(read_from_stdin(),
                           boost::bind(handle_query,
                                       amy::placeholders::error,

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -16,13 +16,7 @@ void handle_store_result(boost::system::error_code const& ec,
                          amy::result_set result_set,
                          amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Failed to store result: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-    }
-
+    check_error(ec);
     std::copy(result_set.begin(),
               result_set.end(),
               std::ostream_iterator<amy::row>(std::cout, "\n"));
@@ -39,13 +33,7 @@ void handle_store_result(boost::system::error_code const& ec,
 void handle_query(boost::system::error_code const& ec,
                   amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Query error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-    }
-
+    check_error(ec);
     connector.async_store_result(
             boost::bind(handle_store_result,
                         amy::placeholders::error,
@@ -56,16 +44,10 @@ void handle_query(boost::system::error_code const& ec,
 void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Connection error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-        return;
-    }
-
+    check_error(ec);
     std::cout << "Connected." << std::endl;
 
+    // Executes multiple ';'-separated SQL queries read from stdin
     connector.async_query(read_from_stdin(),
                           boost::bind(handle_query,
                                       amy::placeholders::error,

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -13,7 +13,7 @@
 global_options opts;
 
 void handle_store_result(boost::system::error_code const& ec,
-                         amy::result_set result_set,
+                         amy::result_set rs,
                          amy::connector& connector)
 {
     if (!!ec) {
@@ -23,8 +23,7 @@ void handle_store_result(boost::system::error_code const& ec,
             << std::endl;
     }
 
-    std::copy(result_set.begin(),
-              result_set.end(),
+    std::copy(rs.begin(), rs.end(),
               std::ostream_iterator<amy::row>(std::cout, "\n"));
 }
 
@@ -58,7 +57,12 @@ void handle_connect(boost::system::error_code const& ec,
 
     std::cout << "Connected." << std::endl;
 
-    std::string statement = "SHOW DATABASES;";
+    std::string statement =
+        "SELECT * FROM\n"
+        "information_schema.character_sets\n"
+        "WHERE\n"
+        "CHARACTER_SET_NAME LIKE 'latin%'";
+
     connector.async_query(statement,
                           boost::bind(handle_query,
                                       amy::placeholders::error,

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
@@ -72,14 +71,13 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::async_connect(_connector = connector,
-                       _endpoint  = opts.tcp_endpoint(),
-                       _auth      = opts.auth_info(),
-                       _handler   = boost::bind(handle_connect,
-                                                amy::placeholders::error,
-                                                boost::ref(connector)));
+    connector.async_connect(opts.tcp_endpoint(),
+                            opts.auth_info(),
+                            opts.schema,
+                            amy::default_flags,
+                            boost::bind(handle_connect,
+                                        amy::placeholders::error,
+                                        boost::ref(connector)));
 
     io_service.run();
 

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -16,13 +16,7 @@ void handle_store_result(boost::system::error_code const& ec,
                          amy::result_set rs,
                          amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Failed to store result: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-    }
-
+    check_error(ec);
     std::copy(rs.begin(), rs.end(),
               std::ostream_iterator<amy::row>(std::cout, "\n"));
 }
@@ -30,13 +24,7 @@ void handle_store_result(boost::system::error_code const& ec,
 void handle_query(boost::system::error_code const& ec,
                   amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Query error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-    }
-
+    check_error(ec);
     connector.async_store_result(
             boost::bind(handle_store_result,
                         amy::placeholders::error,
@@ -47,14 +35,7 @@ void handle_query(boost::system::error_code const& ec,
 void handle_connect(boost::system::error_code const& ec,
                     amy::connector& connector)
 {
-    if (!!ec) {
-        std::cerr
-            << boost::format("Connection error: %1% - %2%")
-               % ec.value() % ec.message()
-            << std::endl;
-        return;
-    }
-
+    check_error(ec);
     std::cout << "Connected." << std::endl;
 
     std::string statement =

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -39,10 +39,9 @@ void handle_connect(boost::system::error_code const& ec,
     std::cout << "Connected." << std::endl;
 
     std::string statement =
-        "SELECT * FROM\n"
-        "information_schema.character_sets\n"
-        "WHERE\n"
-        "CHARACTER_SET_NAME LIKE 'latin%'";
+        "SELECT *\n"
+        "FROM information_schema.character_sets\n"
+        "WHERE CHARACTER_SET_NAME LIKE 'latin%'";
 
     connector.async_query(statement,
                           boost::bind(handle_query,

--- a/example/blocking_connect.cpp
+++ b/example/blocking_connect.cpp
@@ -1,5 +1,6 @@
 #include "utils.hpp"
 
+#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 
 #include <boost/asio/io_service.hpp>
@@ -16,10 +17,12 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    connector.connect(opts.tcp_endpoint(),
-                      opts.auth_info(),
-                      opts.schema,
-                      amy::default_flags);
+    using namespace amy::keyword;
+
+    amy::connect(_connector = connector,
+                 _endpoint  = opts.tcp_endpoint(),
+                 _auth      = opts.auth_info(),
+                 _database  = opts.schema);
 
     std::cout << "Connected." << std::endl;
 

--- a/example/blocking_connect.cpp
+++ b/example/blocking_connect.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 
 #include <boost/asio/io_service.hpp>
@@ -17,12 +16,10 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::connect(_connector = connector,
-                 _endpoint  = opts.tcp_endpoint(),
-                 _auth      = opts.auth_info(),
-                 _database  = opts.schema);
+    connector.connect(opts.tcp_endpoint(),
+                      opts.auth_info(),
+                      opts.schema,
+                      amy::default_flags);
 
     std::cout << "Connected." << std::endl;
 

--- a/example/blocking_execute.cpp
+++ b/example/blocking_execute.cpp
@@ -23,6 +23,7 @@ int main(int argc, char* argv[]) try {
                       opts.schema,
                       amy::default_flags);
 
+    // Executes an arbitrary SQL statement read from stdin.
     auto affected_rows = amy::execute(connector, read_from_stdin());
     std::cout << "Affected rows: " << affected_rows << std::endl;
 

--- a/example/blocking_execute.cpp
+++ b/example/blocking_execute.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/execute.hpp>
 
@@ -19,12 +18,10 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::connect(_connector = connector,
-                 _endpoint  = opts.tcp_endpoint(),
-                 _auth      = opts.auth_info(),
-                 _database  = opts.schema);
+    connector.connect(opts.tcp_endpoint(),
+                      opts.auth_info(),
+                      opts.schema,
+                      amy::default_flags);
 
     std::cout
         << boost::format("Affected rows: %3%, contents:\n")

--- a/example/blocking_execute.cpp
+++ b/example/blocking_execute.cpp
@@ -23,10 +23,8 @@ int main(int argc, char* argv[]) try {
                       opts.schema,
                       amy::default_flags);
 
-    std::cout
-        << boost::format("Affected rows: %3%, contents:\n")
-           % amy::execute(connector, read_from_stdin())
-        << std::endl;
+    auto affected_rows = amy::execute(connector, read_from_stdin());
+    std::cout << "Affected rows: " << affected_rows << std::endl;
 
     return 0;
 } catch (boost::system::system_error const& e) {

--- a/example/blocking_multi_query.cpp
+++ b/example/blocking_multi_query.cpp
@@ -23,23 +23,23 @@ int main(int argc, char* argv[]) try {
                       opts.schema,
                       amy::client_multi_statements);
 
+    // Executes multiple ';'-separated SQL queries read from stdin.
     connector.query(read_from_stdin());
 
     auto first = amy::results_iterator(connector);
     auto last = amy::results_iterator();
 
-    std::for_each(first, last, [](amy::result_set& rs) {
-        if (rs.empty()) {
-            std::cout << "Affected rows: " << rs.affected_rows() << std::endl;
-        } else {
-            std::cout
-                << boost::format("Field count: %1%, result set size: %2%")
-                   % rs.field_count() % rs.size()
-                << std::endl;
+    // Prints result sets of each executed query.
+    std::for_each(first, last, [](const amy::result_set& rs) {
+        std::cout
+            << boost::format("Affected rows: %1%, "
+                             "field count: %2%, "
+                             "result set size %3%")
+               % rs.affected_rows() % rs.field_count() % rs.size()
+            << std::endl;
 
-            auto out = std::ostream_iterator<amy::row>(std::cout, "\n");
-            std::copy(rs.begin(), rs.end(), out);
-        }
+        auto out = std::ostream_iterator<amy::row>(std::cout, "\n");
+        std::copy(rs.begin(), rs.end(), out);
     });
 
     return 0;

--- a/example/blocking_multi_query.cpp
+++ b/example/blocking_multi_query.cpp
@@ -1,8 +1,6 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
-#include <amy/client_flags.hpp>
 
 #include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
@@ -34,11 +32,10 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    amy::connect(connector,
-                 opts.tcp_endpoint(),
-                 opts.auth_info(),
-                 opts.schema,
-                 amy::client_multi_statements);
+    connector.connect(opts.tcp_endpoint(),
+                      opts.auth_info(),
+                      opts.schema,
+                      amy::client_multi_statements);
 
     connector.query(read_from_stdin());
 

--- a/example/blocking_multi_query.cpp
+++ b/example/blocking_multi_query.cpp
@@ -37,11 +37,13 @@ int main(int argc, char* argv[]) try {
                       opts.schema,
                       amy::client_multi_statements);
 
+    // Executes multiple ';'-separated SQL queries read from stdin
     connector.query(read_from_stdin());
 
-    std::for_each(amy::results_iterator(connector),
-                  amy::results_iterator(),
-                  &print_result_set);
+    // Prints all result sets using amy::results_iterator
+    auto first = amy::results_iterator(connector);
+    auto last = amy::results_iterator();
+    std::for_each(first, last, &print_result_set);
 
     return 0;
 } catch (boost::system::system_error const& e) {

--- a/example/blocking_single_query.cpp
+++ b/example/blocking_single_query.cpp
@@ -23,25 +23,30 @@ int main(int argc, char* argv[]) try {
                       amy::default_flags);
 
     std::string statement =
-        "SELECT *\n"
+        "SELECT character_set_name, maxlen\n"
         "FROM information_schema.character_sets\n"
-        "WHERE CHARACTER_SET_NAME LIKE 'latin%'";
+        "WHERE character_set_name LIKE 'latin%'";
 
     connector.query(statement);
 
-    amy::result_set result_set = connector.store_result();
+    amy::result_set rs = connector.store_result();
+
     std::cout
         << boost::format("Field count: %1%, "
                          "result set size: %2%, "
-                         "affected rows: %3%, contents:\n")
-           % result_set.field_count()
-           % result_set.size()
-           % result_set.affected_rows()
+                         "affected rows: %3%, contents:")
+           % rs.field_count() % rs.size() % rs.affected_rows()
         << std::endl;
 
-    std::copy(result_set.begin(),
-              result_set.end(),
-              std::ostream_iterator<amy::row>(std::cout, "\n"));
+    const auto& fields_info = rs.fields_info();
+
+    for (const auto& row : rs) {
+        std::cout
+            << boost::format("%1%: %2%, %3%: %4%")
+               % fields_info[0].name() % row[0].as<std::string>()
+               % fields_info[1].name() % row[1].as<amy::sql_bigint>()
+            << std::endl;
+    }
 
     return 0;
 } catch (boost::system::system_error const& e) {

--- a/example/blocking_single_query.cpp
+++ b/example/blocking_single_query.cpp
@@ -23,9 +23,9 @@ int main(int argc, char* argv[]) try {
                       amy::default_flags);
 
     std::string statement =
-        "SELECT * FROM "
-        "information_schema.character_sets "
-        "WHERE "
+        "SELECT * FROM\n"
+        "information_schema.character_sets\n"
+        "WHERE\n"
         "CHARACTER_SET_NAME LIKE 'latin%'";
 
     connector.query(statement);

--- a/example/blocking_single_query.cpp
+++ b/example/blocking_single_query.cpp
@@ -23,10 +23,9 @@ int main(int argc, char* argv[]) try {
                       amy::default_flags);
 
     std::string statement =
-        "SELECT * FROM\n"
-        "information_schema.character_sets\n"
-        "WHERE\n"
-        "CHARACTER_SET_NAME LIKE 'latin%'";
+        "SELECT *\n"
+        "FROM information_schema.character_sets\n"
+        "WHERE CHARACTER_SET_NAME LIKE 'latin%'";
 
     connector.query(statement);
 

--- a/example/blocking_single_query.cpp
+++ b/example/blocking_single_query.cpp
@@ -1,6 +1,5 @@
 #include "utils.hpp"
 
-#include <amy/connect.hpp>
 #include <amy/connector.hpp>
 
 #include <boost/asio/io_service.hpp>
@@ -18,12 +17,10 @@ int main(int argc, char* argv[]) try {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
-    using namespace amy::keyword;
-
-    amy::connect(_connector = connector,
-                 _endpoint  = opts.tcp_endpoint(),
-                 _auth      = opts.auth_info(),
-                 _database  = opts.schema);
+    connector.connect(opts.tcp_endpoint(),
+                      opts.auth_info(),
+                      opts.schema,
+                      amy::default_flags);
 
     std::string statement =
         "SELECT * FROM "

--- a/example/utils.cpp
+++ b/example/utils.cpp
@@ -67,3 +67,9 @@ std::string read_from_stdin() {
 
     return str;
 }
+
+void check_error(boost::system::error_code const& ec) {
+    if (!!ec) {
+        boost::throw_exception(boost::system::system_error(ec));
+    }
+}

--- a/example/utils.hpp
+++ b/example/utils.hpp
@@ -35,4 +35,6 @@ void parse_command_line_options(int argc, char* argv[]);
 
 std::string read_from_stdin();
 
+void check_error(boost::system::error_code const& ec);
+
 #endif // __AMY_EXAMPLE_UTILS_HPP__

--- a/include/amy/connect.hpp
+++ b/include/amy/connect.hpp
@@ -10,52 +10,6 @@
 #include <boost/system/error_code.hpp>
 
 namespace amy {
-namespace detail {
-
-template<
-    typename MySQLConnector,
-    typename Endpoint
->
-void connect(MySQLConnector& connector,
-             Endpoint const& endpoint,
-             auth_info const& auth,
-             std::string const& database,
-             client_flags flags = default_flags)
-{
-    connector.connect(endpoint, auth, database, flags);
-}
-
-template<
-    typename MySQLConnector,
-    typename Endpoint
->
-boost::system::error_code connect(MySQLConnector& connector,
-                                  Endpoint const& endpoint,
-                                  auth_info const& auth,
-                                  std::string const& database,
-                                  client_flags flags,
-                                  boost::system::error_code& ec)
-{
-    return connector.connect(endpoint, auth, database, flags, ec);
-}
-
-template<
-    typename MySQLConnector,
-    typename Endpoint,
-    typename ConnectHandler
->
-void async_connect(MySQLConnector& connector,
-                   Endpoint const& endpoint,
-                   auth_info const& auth,
-                   std::string const& database,
-                   client_flags flags,
-                   ConnectHandler handler)
-{
-    connector.async_connect(endpoint, auth, database, flags, handler);
-}
-
-} // namespace detail
-
 namespace keyword {
 
 BOOST_PARAMETER_NAME(connector)
@@ -81,7 +35,7 @@ BOOST_PARAMETER_FUNCTION(
             (database, *, std::string())
             (flags,    *, amy::default_flags)))
 {
-    detail::connect(connector, endpoint, auth, database, flags);
+    connector.connect(endpoint, auth, database, flags);
 }
 
 inline void ignore_connect_event(boost::system::error_code const&) {
@@ -102,8 +56,7 @@ BOOST_PARAMETER_FUNCTION(
             (flags,    *, amy::default_flags)
             (handler,  *, &ignore_connect_event)))
 {
-    detail::async_connect(
-            connector, endpoint, auth, database, flags, handler);
+    connector.async_connect(endpoint, auth, database, flags, handler);
 }
 
 } // namespace amy

--- a/include/amy/detail/throw_error.hpp
+++ b/include/amy/detail/throw_error.hpp
@@ -18,8 +18,7 @@ inline void throw_error(boost::system::error_code const& ec,
         if (ec.category() == amy::error::get_client_category()) {
             amy::system_error e(ec, ::mysql_error(m));
             boost::throw_exception(e);
-        }
-        else {
+        } else {
             amy::system_error e(ec);
             boost::throw_exception(e);
         }

--- a/include/amy/field.hpp
+++ b/include/amy/field.hpp
@@ -42,10 +42,9 @@ private:
 }; // class field
 
 inline std::ostream& operator<<(std::ostream& out, field const& f) {
-    if(f.is_null()) {
+    if (f.is_null()) {
         return out << "null";
-    }
-    else {
+    } else {
         return out << f.value_str_;
     }
 }

--- a/include/amy/result_set.hpp
+++ b/include/amy/result_set.hpp
@@ -14,7 +14,7 @@ namespace amy {
 /// Provides MySQL query result set functionality.
 /**
  * The \c result_set class wraps the underlying \c MYSQL_RES* pointer returned
- * by a \c ::mysql_store_result() call. It also provides STL compatible random
+ * by a \c mysql_store_result() call. It also provides STL compatible random
  * access iterator over rows in the result set.
  */
 class result_set {


### PR DESCRIPTION
This PR resolves #2:

1. Add new example `async_execute.cpp` to illustrate `async_execute()`.
2. Only use `connect()` with named parameters in connect examples.
3. Illustrate how to access row fields in single query examples.
4. Simplify existing examples