### PR TITLE
#6: Migrate test code to Boost.Test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rdparty/googletest"]
-	path = 3rdparty/googletest
-	url = https://github.com/google/googletest.git

--- a/example/SConscript
+++ b/example/SConscript
@@ -1,14 +1,14 @@
 Import('env')
 Import('libs')
 
-libs.extend(['boost_program_options'])
+example_libs = libs + (['boost_program_options'])
 
 utils = env.Object(source='utils.cpp')
 
 [env.Program(target=example,
              source=['%s.cpp' % (example),
                      utils],
-             LIBS=libs)
+             LIBS=example_libs)
  for example in ['async_connect',
                  'async_execute',
                  'async_multi_query',

--- a/example/utils.cpp
+++ b/example/utils.cpp
@@ -73,3 +73,5 @@ void check_error(boost::system::error_code const& ec) {
         boost::throw_exception(boost::system::system_error(ec));
     }
 }
+
+// vim:ft=cpp ts=4 sw=4 et

--- a/include/amy/auth_info.hpp
+++ b/include/amy/auth_info.hpp
@@ -70,7 +70,7 @@ public:
     /// Gets the password.
     /**
      * \return Returns the password set previously.  If no password is set,
-     *         returns NULL.
+     *         returns \c nullptr.
      */
     char const* password() const {
         return !!password_ ? password_->c_str() : nullptr;

--- a/test/SConscript
+++ b/test/SConscript
@@ -1,15 +1,11 @@
 Import('env')
 Import('libs')
 
-GTEST_ROOT = '#3rdparty/googletest/googletest'
-
-env.Prepend(CPPPATH=[Dir(GTEST_ROOT + '/include'),
-                     Dir(GTEST_ROOT)])
+test_libs = libs + ['boost_unit_test_framework']
 
 program = env.Program(target='test',
-                      source=[env.Glob('*.cpp'),
-                              env.File(GTEST_ROOT + '/src/gtest-all.cc')],
-                      LIBS=libs)
+                      source=[env.Glob('*.cpp')],
+                      LIBS=test_libs)
 
 [env.Command(target='run-test',
              source=p,

--- a/test/async_connect_test.cpp
+++ b/test/async_connect_test.cpp
@@ -1,29 +1,25 @@
-#include <gtest/gtest.h>
+#include <boost/test/unit_test.hpp>
 
 #include <amy/connect.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
-#include <boost/bind.hpp>
-
-class async_connect_test : public testing::Test {
-protected:
+struct async_connect_test {
     bool handler_invoked;
 
-    virtual void SetUp() {
+    async_connect_test() {
         handler_invoked = false;
     } 
 
-public:
     void handle_connect(boost::system::error_code const& ec) {
         handler_invoked = true;
     }
 
-}; // class async_connect_test
+}; // struct async_connect_test
 
-TEST_F(async_connect_test,
-       should_connect_to_localhost_with_given_auth_info)
-{
+BOOST_AUTO_TEST_CASE(should_async_connect_to_localhost_with_given_auth_info) {
+    async_connect_test fixture;
+
     boost::asio::io_service io_service;
     amy::connector c(io_service);
 
@@ -33,10 +29,12 @@ TEST_F(async_connect_test,
                        _auth      = amy::auth_info("amy", "amy"),
                        _handler   = boost::bind(
                                         &async_connect_test::handle_connect,
-                                        this,
+                                        &fixture,
                                         amy::placeholders::error));
 
     io_service.run();
 
-    ASSERT_TRUE(handler_invoked);
+    BOOST_CHECK(fixture.handler_invoked);
 }
+
+// vim:ft=cpp ts=4 sw=4 tw=80 et

--- a/test/auth_info_test.cpp
+++ b/test/auth_info_test.cpp
@@ -1,51 +1,41 @@
-#include <gtest/gtest.h>
+#include <boost/test/unit_test.hpp>
 
 #include <amy/auth_info.hpp>
 
-TEST(auth_info_test,
-     should_construct_instance_with_anonymous_user)
-{
+BOOST_AUTO_TEST_CASE(should_construct_instance_with_anonymous_user) {
     amy::auth_info auth;
-    ASSERT_STREQ("", auth.user());
+    BOOST_TEST("" == auth.user());
 }
 
-TEST(auth_info_test,
-     should_construct_instance_without_password)
-{
+BOOST_AUTO_TEST_CASE(should_construct_instance_without_password) {
     amy::auth_info auth;
-    ASSERT_EQ(nullptr, auth.password());
+    BOOST_TEST(static_cast<const char*>(nullptr) == auth.password());
 }
 
-TEST(auth_info_test,
-     should_construct_instance_with_user)
-{
+BOOST_AUTO_TEST_CASE(should_construct_instance_with_user) {
     amy::auth_info auth("user");
-    ASSERT_STREQ("user", auth.user());
+    BOOST_TEST("user" == auth.user());
 }
 
-TEST(auth_info_test,
-     should_construct_instance_with_user_and_nonempty_password)
-{
+BOOST_AUTO_TEST_CASE(
+    should_construct_instance_with_user_and_nonempty_password
+) {
     amy::auth_info auth("user", "secret");
-    ASSERT_STREQ("user", auth.user());
-    ASSERT_STREQ("secret", auth.password());
+    BOOST_TEST("user", auth.user());
+    BOOST_TEST("secret" == auth.password());
 }
 
-TEST(auth_info_test,
-     should_return_previously_set_password)
-{
+BOOST_AUTO_TEST_CASE(should_return_previously_set_password) {
     amy::auth_info auth;
     auth.password("secret");
-    ASSERT_STREQ("secret", auth.password());
+    BOOST_TEST("secret" == auth.password());
 }
 
-TEST(auth_info_test,
-     should_return_null_after_clearing_password)
-{
+BOOST_AUTO_TEST_CASE(should_return_null_after_clearing_password) {
     amy::auth_info auth;
     auth.password("secret");
     auth.clear_password();
-    ASSERT_EQ(nullptr, auth.password());
+    BOOST_TEST(static_cast<const char*>(nullptr) == auth.password());
 }
 
-// vim:ft=cpp ts=4 sw=4 et
+// vim:ft=cpp ts=4 sw=4 tw=80 et

--- a/test/blocking_connect_test.cpp
+++ b/test/blocking_connect_test.cpp
@@ -1,14 +1,14 @@
-#include <gtest/gtest.h>
+#include <boost/test/unit_test.hpp>
 
 #include <amy/connect.hpp>
 #include <amy/connector.hpp>
 
-TEST(blocking_connect_test,
-     should_connect_to_localhost_with_given_auth_info)
-{
+BOOST_AUTO_TEST_CASE(should_connect_to_localhost_with_given_auth_info) {
     using namespace amy::keyword;
 
     boost::asio::io_service io_service;
     amy::connector c(io_service);
     amy::connect(c, _auth = amy::auth_info("amy", "amy"));
 }
+
+// vim:ft=cpp ts=4 sw=4 tw=80 et

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -1,35 +1,31 @@
-#include <gtest/gtest.h>
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
 
 #include <amy/connector.hpp>
 
-TEST(connector_test,
-     should_construct_a_connector_instance)
-{
+BOOST_AUTO_TEST_CASE(should_construct_a_connector_instance) {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 }
 
-TEST(connector_test,
-     should_be_opened_successfully)
-{
+BOOST_AUTO_TEST_CASE(should_be_opened_successfully) {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
     connector.open();
-    ASSERT_TRUE(connector.is_open());
+    BOOST_CHECK(connector.is_open());
 }
 
-TEST(connector_test,
-     should_be_closed_successfully)
-{
+BOOST_AUTO_TEST_CASE(should_be_closed_successfully) {
     boost::asio::io_service io_service;
     amy::connector connector(io_service);
 
     connector.open();
-    ASSERT_TRUE(connector.is_open());
+    BOOST_CHECK(connector.is_open());
 
     connector.close();
-    ASSERT_FALSE(connector.is_open());
+    BOOST_CHECK(!connector.is_open());
 }
 
 // vim:ft=cpp ts=4 sw=4 et

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,9 +1,4 @@
-#include <gtest/gtest.h>
+#define BOOST_TEST_MODULE amy
+#define BOOST_TEST_DYN_LINK
 
-int main(int argc, char* argv[]) try {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-} catch (std::exception& e) {
-    std::cout << "EXCEPTION: " << e.what() << std::endl;
-    throw;
-}
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This PR migrates test code from GoogleTest to Boost.Test.

The `googletest` submodule is no longer needed and is deleted.