### PR TITLE
Allow users to choose between Boost.Asio and vanilla standalone Asio

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -10,6 +10,7 @@ env = Environment(ENV=os.environ,
                   CCFLAGS='-ggdb -O0 -std=c++11',
                   CPPPATH=[Dir('include'),
                            Dir('/usr/local/include')],
+                  CPPDEFINES=['USE_BOOST_ASIO'],
                   LIBPATH=libpath)
 
 libs = ['boost_system',

--- a/example/async_connect.cpp
+++ b/example/async_connect.cpp
@@ -1,18 +1,17 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <functional>
 #include <iostream>
 
 global_options opts;
 
-void handle_connect(boost::system::error_code const& ec,
+void handle_connect(AMY_SYSTEM_NS::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
@@ -22,7 +21,7 @@ void handle_connect(boost::system::error_code const& ec,
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.async_connect(opts.tcp_endpoint(),
@@ -36,7 +35,7 @@ int main(int argc, char* argv[]) try {
     io_service.run();
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -1,19 +1,18 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 #include <amy/execute.hpp>
 #include <amy/placeholders.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <functional>
 #include <iostream>
 
 global_options opts;
 
-void handle_execute(boost::system::error_code const& ec,
+void handle_execute(AMY_SYSTEM_NS::error_code const& ec,
                     uint64_t affected_rows,
                     amy::connector& connector)
 {
@@ -22,7 +21,7 @@ void handle_execute(boost::system::error_code const& ec,
     return;
 }
 
-void handle_connect(boost::system::error_code const& ec,
+void handle_connect(AMY_SYSTEM_NS::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
@@ -39,7 +38,7 @@ void handle_connect(boost::system::error_code const& ec,
 int main(int argc, char* argv[]) {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.async_connect(opts.tcp_endpoint(),

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -1,18 +1,17 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <functional>
 #include <iostream>
 
 global_options opts;
 
-void handle_store_result(boost::system::error_code const& ec,
+void handle_store_result(AMY_SYSTEM_NS::error_code const& ec,
                          amy::result_set rs,
                          amy::connector& connector)
 {
@@ -38,7 +37,7 @@ void handle_store_result(boost::system::error_code const& ec,
     }
 }
 
-void handle_query(boost::system::error_code const& ec,
+void handle_query(AMY_SYSTEM_NS::error_code const& ec,
                   amy::connector& connector)
 {
     check_error(ec);
@@ -50,7 +49,7 @@ void handle_query(boost::system::error_code const& ec,
                       std::ref(connector)));
 }
 
-void handle_connect(boost::system::error_code const& ec,
+void handle_connect(AMY_SYSTEM_NS::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
@@ -65,7 +64,7 @@ void handle_connect(boost::system::error_code const& ec,
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.async_connect(opts.tcp_endpoint(),
@@ -79,7 +78,7 @@ int main(int argc, char* argv[]) try {
     io_service.run();
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -1,18 +1,16 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 #include <amy/placeholders.hpp>
 
-#include <boost/asio/io_service.hpp>
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <iostream>
 
 global_options opts;
 
-void handle_store_result(boost::system::error_code const& ec,
+void handle_store_result(AMY_SYSTEM_NS::error_code const& ec,
                          amy::result_set rs,
                          amy::connector& connector)
 {
@@ -36,7 +34,7 @@ void handle_store_result(boost::system::error_code const& ec,
     }
 }
 
-void handle_query(boost::system::error_code const& ec,
+void handle_query(AMY_SYSTEM_NS::error_code const& ec,
                   amy::connector& connector)
 {
     check_error(ec);
@@ -48,7 +46,7 @@ void handle_query(boost::system::error_code const& ec,
                       std::ref(connector)));
 }
 
-void handle_connect(boost::system::error_code const& ec,
+void handle_connect(AMY_SYSTEM_NS::error_code const& ec,
                     amy::connector& connector)
 {
     check_error(ec);
@@ -67,7 +65,7 @@ void handle_connect(boost::system::error_code const& ec,
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.async_connect(opts.tcp_endpoint(),
@@ -81,7 +79,7 @@ int main(int argc, char* argv[]) try {
     io_service.run();
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/blocking_connect.cpp
+++ b/example/blocking_connect.cpp
@@ -1,10 +1,9 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <iostream>
 
@@ -13,7 +12,7 @@ global_options opts;
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.connect(opts.tcp_endpoint(),
@@ -24,7 +23,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "Connected." << std::endl;
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/blocking_execute.cpp
+++ b/example/blocking_execute.cpp
@@ -1,9 +1,9 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 #include <amy/execute.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
 
 #include <algorithm>
@@ -15,7 +15,7 @@ global_options opts;
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.connect(opts.tcp_endpoint(),
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) try {
     std::cout << "Affected rows: " << affected_rows << std::endl;
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/blocking_multi_query.cpp
+++ b/example/blocking_multi_query.cpp
@@ -1,10 +1,9 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
-#include <boost/system/system_error.hpp>
 
 #include <algorithm>
 #include <iostream>
@@ -15,7 +14,7 @@ global_options opts;
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.connect(opts.tcp_endpoint(),
@@ -43,7 +42,7 @@ int main(int argc, char* argv[]) try {
     });
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/blocking_single_query.cpp
+++ b/example/blocking_single_query.cpp
@@ -1,8 +1,8 @@
 #include "utils.hpp"
 
+#include <amy/asio.hpp>
 #include <amy/connector.hpp>
 
-#include <boost/asio/io_service.hpp>
 #include <boost/format.hpp>
 
 #include <algorithm>
@@ -14,7 +14,7 @@ global_options opts;
 int main(int argc, char* argv[]) try {
     parse_command_line_options(argc, argv);
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.connect(opts.tcp_endpoint(),
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) try {
     }
 
     return 0;
-} catch (boost::system::system_error const& e) {
+} catch (AMY_SYSTEM_NS::system_error const& e) {
     std::cerr
         << boost::format("System error: %1%: %2%")
            % e.code().value() % e.what()

--- a/example/utils.cpp
+++ b/example/utils.cpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <iterator>
 
-boost::asio::ip::tcp::endpoint global_options::tcp_endpoint() const {
-    using namespace boost::asio::ip;
+AMY_ASIO_NS::ip::tcp::endpoint global_options::tcp_endpoint() const {
+    using namespace AMY_ASIO_NS::ip;
 
     return host.empty() ?
         tcp::endpoint(address_v4::loopback(), port) :
@@ -68,9 +68,9 @@ std::string read_from_stdin() {
     return str;
 }
 
-void check_error(boost::system::error_code const& ec) {
+void check_error(AMY_SYSTEM_NS::error_code const& ec) {
     if (ec) {
-        boost::throw_exception(boost::system::system_error(ec));
+        boost::throw_exception(AMY_SYSTEM_NS::system_error(ec));
     }
 }
 

--- a/example/utils.hpp
+++ b/example/utils.hpp
@@ -1,9 +1,9 @@
 #ifndef __AMY_EXAMPLE_UTILS_HPP__
 #define __AMY_EXAMPLE_UTILS_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/auth_info.hpp>
 
-#include <boost/asio/ip/tcp.hpp>
 #include <boost/optional.hpp>
 
 /// Global options.
@@ -23,7 +23,7 @@ struct global_options {
     /// Default schema to use.
     std::string schema;
 
-    boost::asio::ip::tcp::endpoint tcp_endpoint() const;
+    AMY_ASIO_NS::ip::tcp::endpoint tcp_endpoint() const;
 
     amy::auth_info auth_info() const;
 
@@ -35,7 +35,7 @@ void parse_command_line_options(int argc, char* argv[]);
 
 std::string read_from_stdin();
 
-void check_error(boost::system::error_code const& ec);
+void check_error(AMY_SYSTEM_NS::error_code const& ec);
 
 #endif // __AMY_EXAMPLE_UTILS_HPP__
 

--- a/include/amy/asio.hpp
+++ b/include/amy/asio.hpp
@@ -1,0 +1,31 @@
+#ifndef __AMY_ASIO_HPP__
+#define __AMY_ASIO_HPP__
+
+#if defined(USE_BOOST_ASIO)
+
+#include <boost/asio/basic_io_object.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/local/stream_protocol.hpp>
+#include <boost/asio/placeholders.hpp>
+#include <boost/system/system_error.hpp>
+
+#define AMY_ASIO_NS ::boost::asio
+#define AMY_SYSTEM_NS ::boost::system
+
+#else
+
+#include <asio/basic_io_object.hpp>
+#include <asio/io_service.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/local/stream_protocol.hpp>
+#include <asio/placeholders.hpp>
+
+#include <system_error>
+
+#define AMY_ASIO_NS ::asio
+#define AMY_SYSTEM_NS ::std
+
+#endif
+
+#endif // __AMY_ASIO_HPP__

--- a/include/amy/basic_connector.hpp
+++ b/include/amy/basic_connector.hpp
@@ -1,20 +1,17 @@
 #ifndef __AMY_BASIC_CONNECTOR_HPP__
 #define __AMY_BASIC_CONNECTOR_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/auth_info.hpp>
 #include <amy/client_flags.hpp>
 #include <amy/detail/throw_error.hpp>
 #include <amy/result_set.hpp>
 
-#include <boost/asio/basic_io_object.hpp>
-#include <boost/asio/io_service.hpp>
-#include <boost/system/system_error.hpp>
-
 namespace amy {
 
 /// Provides MySQL client functionalities.
 template<typename MySQLService>
-class basic_connector : public boost::asio::basic_io_object<MySQLService> {
+class basic_connector : public AMY_ASIO_NS::basic_io_object<MySQLService> {
 public:
     /// The type of the service that provides actual MySQL client
     /// functionalities.
@@ -24,24 +21,24 @@ public:
     typedef typename service_type::native_type native_type;
 
     /// Constructs a \c basic_connector without opening it.
-    explicit basic_connector(boost::asio::io_service& io_service) :
-        boost::asio::basic_io_object<MySQLService>(io_service)
+    explicit basic_connector(AMY_ASIO_NS::io_service& io_service) :
+        AMY_ASIO_NS::basic_io_object<MySQLService>(io_service)
     {}
 
     native_type native() {
         return this->service.native(this->implementation);
     }
 
-    std::string error_message(boost::system::error_code const& ec) {
+    std::string error_message(AMY_SYSTEM_NS::error_code const& ec) {
         return this->service.error_message(this->implementation, ec);
     }
 
     void open() {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(open(ec), &(this->implementation.mysql));
     }
 
-    boost::system::error_code open(boost::system::error_code& ec) {
+    AMY_SYSTEM_NS::error_code open(AMY_SYSTEM_NS::error_code& ec) {
         return this->service.open(this->implementation, ec);
     }
 
@@ -55,14 +52,14 @@ public:
 
     template<typename Option>
     void set_option(Option const& option) {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(set_option(this->implementation, option, ec),
                             &(this->implementation.mysql));
     }
 
     template<typename Option>
-    boost::system::error_code set_option(Option const& option,
-                                         boost::system::error_code& ec)
+    AMY_SYSTEM_NS::error_code set_option(Option const& option,
+                                         AMY_SYSTEM_NS::error_code& ec)
     {
         this->service.set_option(this->implementation, option, ec);
         detail::throw_error(ec, &(this->implementation.mysql));
@@ -78,17 +75,17 @@ public:
                  std::string const& database,
                  client_flags flags)
     {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(connect(endpoint, auth, database, flags, ec),
                             &(this->implementation.mysql));
     }
 
     template<typename Endpoint>
-    boost::system::error_code connect(Endpoint const& endpoint,
+    AMY_SYSTEM_NS::error_code connect(Endpoint const& endpoint,
                                       auth_info const& auth,
                                       std::string const& database,
                                       client_flags flags,
-                                      boost::system::error_code& ec)
+                                      AMY_SYSTEM_NS::error_code& ec)
     {
         return this->service.connect(this->implementation,
                                      endpoint, auth, database, flags, ec);
@@ -106,12 +103,12 @@ public:
     }
 
     void query(std::string const& stmt) {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(query(stmt, ec), &(this->implementation.mysql));
     }
 
-    boost::system::error_code query(std::string const& stmt,
-                                    boost::system::error_code& ec)
+    AMY_SYSTEM_NS::error_code query(std::string const& stmt,
+                                    AMY_SYSTEM_NS::error_code& ec)
     {
         return this->service.query(this->implementation, stmt, ec);
     }
@@ -126,13 +123,13 @@ public:
     }
 
     result_set store_result() {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         result_set rs = store_result(ec);
         detail::throw_error(ec, &(this->implementation.mysql));
         return rs;
     }
 
-    result_set store_result(boost::system::error_code& ec) {
+    result_set store_result(AMY_SYSTEM_NS::error_code& ec) {
         return this->service.store_result(this->implementation, ec);
     }
 
@@ -142,34 +139,34 @@ public:
     }
 
     void autocommit(bool mode) {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(autocommit(mode, ec),
                             &(this->implementation.mysql));
     }
 
-    boost::system::error_code autocommit(bool mode,
-                                         boost::system::error_code& ec)
+    AMY_SYSTEM_NS::error_code autocommit(bool mode,
+                                         AMY_SYSTEM_NS::error_code& ec)
     {
         this->service.autocommit(this->implementation, mode, ec);
         return ec;
     }
 
     void commit() {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(commit(ec), &(this->implementation.mysql));
     }
 
-    boost::system::error_code commit(boost::system::error_code& ec) {
+    AMY_SYSTEM_NS::error_code commit(AMY_SYSTEM_NS::error_code& ec) {
         this->service.commit(this->implementation, ec);
         return ec;
     }
 
     void rollback() {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         detail::throw_error(rollback(ec), &(this->implementation.mysql));
     }
 
-    boost::system::error_code rollback(boost::system::error_code& ec) {
+    AMY_SYSTEM_NS::error_code rollback(AMY_SYSTEM_NS::error_code& ec) {
         this->service.rollback(this->implementation, ec);
         return ec;
     }

--- a/include/amy/basic_results_iterator.hpp
+++ b/include/amy/basic_results_iterator.hpp
@@ -48,7 +48,7 @@ public:
         end_(false)
     {
         if (!connector_->is_open()) {
-            boost::system::error_code ec = amy::error::not_initialized;
+            AMY_SYSTEM_NS::error_code ec = amy::error::not_initialized;
             amy::detail::throw_error(ec, connector_->native());
         }
 

--- a/include/amy/basic_scoped_transaction.hpp
+++ b/include/amy/basic_scoped_transaction.hpp
@@ -1,9 +1,8 @@
 #ifndef __AMY_TRANSACTION_HPP__
 #define __AMY_TRANSACTION_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/basic_connector.hpp>
-
-#include <boost/system/error_code.hpp>
 
 namespace amy {
 
@@ -24,7 +23,7 @@ public:
         committed_ = true;
     }
 
-    boost::system::error_code commit(boost::system::error_code& ec) {
+    AMY_SYSTEM_NS::error_code commit(AMY_SYSTEM_NS::error_code& ec) {
         committed_ = !!connector_.commit(ec);
         return ec;
     }
@@ -33,14 +32,14 @@ public:
         connector_.rollback();
     }
 
-    boost::system::error_code rollback(boost::system::error_code& ec) {
+    AMY_SYSTEM_NS::error_code rollback(AMY_SYSTEM_NS::error_code& ec) {
         return connector_.rollback(ec);
     }
 
 protected:
     ~basic_scoped_transaction() {
         if (!committed_) {
-            boost::system::error_code ec;
+            AMY_SYSTEM_NS::error_code ec;
             connector_.rollback(ec);
         }
         connector_.autocommit(true);

--- a/include/amy/detail/execute_handler.hpp
+++ b/include/amy/detail/execute_handler.hpp
@@ -1,9 +1,8 @@
 #ifndef __AMY_DETAIL_EXECUTE_HANDLER_HPP__
 #define __AMY_DETAIL_EXECUTE_HANDLER_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/basic_connector.hpp>
-
-#include <boost/system/error_code.hpp>
 
 namespace amy {
 namespace detail {
@@ -22,7 +21,7 @@ public:
         handler(handler)
     {}
 
-    void operator()(boost::system::error_code const& ec) {
+    void operator()(AMY_SYSTEM_NS::error_code const& ec) {
         handler(ec, !!ec ? connector.affected_rows() : 0u);
     }
 

--- a/include/amy/detail/mysql_lib_init.hpp
+++ b/include/amy/detail/mysql_lib_init.hpp
@@ -1,10 +1,9 @@
 #ifndef __AMY_DETAIL_MYSQL_LIB_INIT_HPP__
 #define __AMY_DETAIL_MYSQL_LIB_INIT_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/detail/mysql.hpp>
 #include <amy/error.hpp>
-
-#include <boost/system/system_error.hpp>
 
 #include <memory>
 
@@ -30,9 +29,9 @@ private:
             static std::shared_ptr<do_init> init(new do_init());
 
             if (0 != init->result()) {
-                throw boost::system::system_error(
+                throw AMY_SYSTEM_NS::system_error(
                         init->result(),
-                        boost::system::system_category(),
+                        AMY_SYSTEM_NS::system_category(),
                         "mysql_library_init()");
             }
 

--- a/include/amy/detail/mysql_ops.hpp
+++ b/include/amy/detail/mysql_ops.hpp
@@ -26,22 +26,22 @@ using ::mysql_real_escape_string;
 using ::mysql_row_seek;
 using ::mysql_row_tell;
 
-inline void clear_error(boost::system::error_code& ec) {
+inline void clear_error(AMY_SYSTEM_NS::error_code& ec) {
     errno = 0;
-    ec = boost::system::error_code();
+    ec = AMY_SYSTEM_NS::error_code();
 }
 
 template<typename ReturnType>
 ReturnType error_wrapper(ReturnType return_value,
                          mysql_handle m,
-                         boost::system::error_code& ec)
+                         AMY_SYSTEM_NS::error_code& ec)
 {
-    ec = boost::system::error_code(::mysql_errno(m),
+    ec = AMY_SYSTEM_NS::error_code(::mysql_errno(m),
                                    amy::error::get_client_category());
     return return_value;
 }
 
-inline mysql_handle mysql_init(mysql_handle m, boost::system::error_code& ec) {
+inline mysql_handle mysql_init(mysql_handle m, AMY_SYSTEM_NS::error_code& ec) {
     clear_error(ec);
     mysql_handle ret = ::mysql_init(m);
 
@@ -56,7 +56,7 @@ inline mysql_handle mysql_init(mysql_handle m, boost::system::error_code& ec) {
 
 inline void mysql_autocommit(mysql_handle m,
                              bool mode,
-                             boost::system::error_code& ec)
+                             AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     if (::mysql_autocommit(m, mode ? 1 : 0)) {
@@ -72,7 +72,7 @@ inline mysql_handle mysql_real_connect(mysql_handle m,
                                        unsigned int port,
                                        char const* unix_socket,
                                        unsigned long client_flag,
-                                       boost::system::error_code& ec)
+                                       AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     mysql_handle h = ::mysql_real_connect(m, host, user, password, database,
@@ -83,7 +83,7 @@ inline mysql_handle mysql_real_connect(mysql_handle m,
 inline int32_t mysql_real_query(mysql_handle m,
                                 char const* stmt_str,
                                 unsigned long length,
-                                boost::system::error_code& ec)
+                                AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     return error_wrapper(::mysql_real_query(m, stmt_str, length), m, ec);
@@ -95,7 +95,7 @@ inline uint32_t mysql_field_count(const mysql_handle m) {
 }
 
 inline result_set_handle mysql_store_result(mysql_handle m,
-                                            boost::system::error_code& ec)
+                                            AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     return error_wrapper(::mysql_store_result(m), m, ec);
@@ -106,21 +106,21 @@ inline bool mysql_more_results(mysql_handle m) {
     return !!::mysql_more_results(m);
 }
 
-inline int mysql_next_result(mysql_handle m, boost::system::error_code& ec) {
+inline int mysql_next_result(mysql_handle m, AMY_SYSTEM_NS::error_code& ec) {
     clear_error(ec);
     return error_wrapper(::mysql_next_result(m), m, ec);
 }
 
 inline row_type mysql_fetch_row(detail::mysql_handle m,
                                 result_set_handle r,
-                                boost::system::error_code& ec)
+                                AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     return error_wrapper(::mysql_fetch_row(r), m, ec);
 }
 
 inline void mysql_commit(detail::mysql_handle m,
-                         boost::system::error_code& ec)
+                         AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     if (::mysql_commit(m)) {
@@ -129,7 +129,7 @@ inline void mysql_commit(detail::mysql_handle m,
 }
 
 inline void mysql_rollback(detail::mysql_handle m,
-                           boost::system::error_code& ec)
+                           AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     if (::mysql_rollback(m)) {
@@ -140,7 +140,7 @@ inline void mysql_rollback(detail::mysql_handle m,
 inline void mysql_options(detail::mysql_handle m,
                           int option,
                           char const* arg,
-                          boost::system::error_code& ec)
+                          AMY_SYSTEM_NS::error_code& ec)
 {
     clear_error(ec);
     error_wrapper(::mysql_options(m, (enum mysql_option)option, arg), m, ec);

--- a/include/amy/detail/service_base.hpp
+++ b/include/amy/detail/service_base.hpp
@@ -1,7 +1,7 @@
 #ifndef __AMY_DETAIL_SERVICE_BASE_HPP__
 #define __AMY_DETAIL_SERVICE_BASE_HPP__
 
-#include <boost/asio/io_service.hpp>
+#include <amy/asio.hpp>
 
 namespace amy {
 namespace detail {
@@ -9,7 +9,7 @@ namespace detail {
 // TODO Implements our own `service_base` class.
 //
 // Everything inside the `detail` namespace is not part of the public API.
-using boost::asio::detail::service_base;
+using AMY_ASIO_NS::detail::service_base;
 
 } // namespace detail
 } // namespace amy

--- a/include/amy/detail/throw_error.hpp
+++ b/include/amy/detail/throw_error.hpp
@@ -8,7 +8,7 @@
 namespace amy {
 namespace detail {
 
-inline void throw_error(boost::system::error_code const& ec,
+inline void throw_error(AMY_SYSTEM_NS::error_code const& ec,
                         detail::mysql_handle m)
 {
     if (ec) {

--- a/include/amy/endpoint_traits.hpp
+++ b/include/amy/endpoint_traits.hpp
@@ -1,12 +1,11 @@
 #ifndef __AMY_DETAIL_ENDPOINT_TRAITS_HPP__
 #define __AMY_DETAIL_ENDPOINT_TRAITS_HPP__
 
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/local/stream_protocol.hpp>
+#include <amy/asio.hpp>
 
 namespace amy {
 
-using namespace boost::asio;
+using namespace AMY_ASIO_NS;
 
 template<typename Endpoint>
 class endpoint_traits;

--- a/include/amy/error.hpp
+++ b/include/amy/error.hpp
@@ -1,10 +1,9 @@
 #ifndef __AMY_ERROR_HPP__
 #define __AMY_ERROR_HPP__
 
+#include <amy/asio.hpp>
 #include <amy/detail/mysql.hpp>
 #include <amy/detail/mysql_types.hpp>
-
-#include <boost/system/error_code.hpp>
 
 namespace amy {
 namespace error {
@@ -218,13 +217,13 @@ enum misc_errors {
 
 namespace detail {
 
-class client_category : public boost::system::error_category {
+class client_category : public AMY_SYSTEM_NS::error_category {
 public:
     explicit client_category() :
-        boost::system::error_category()
+        AMY_SYSTEM_NS::error_category()
     {}
 
-    char const* name() const BOOST_SYSTEM_NOEXCEPT {
+    char const* name() const noexcept {
         return "mysql";
     }
 
@@ -414,16 +413,16 @@ public:
 
 } // namespace detail
 
-inline boost::system::error_category& get_client_category() {
+inline AMY_SYSTEM_NS::error_category& get_client_category() {
     static detail::client_category instance;
     return instance;
 }
 
 namespace detail {
 
-class misc_category : public boost::system::error_category {
+class misc_category : public AMY_SYSTEM_NS::error_category {
 public:
-    char const* name() const BOOST_SYSTEM_NOEXCEPT {
+    char const* name() const noexcept {
         return "mysql misc";
     }
 
@@ -451,7 +450,7 @@ public:
 
 } // namespace detail
 
-inline boost::system::error_category const& get_misc_category() {
+inline AMY_SYSTEM_NS::error_category const& get_misc_category() {
     static detail::misc_category instance;
     return instance;
 }
@@ -459,8 +458,12 @@ inline boost::system::error_category const& get_misc_category() {
 } // namespace error
 } // namespace amy
 
+#if defined(USE_BOOST_ASIO)
 namespace boost {
 namespace system {
+#else
+namespace std {
+#endif
 
 template<>
 struct is_error_code_enum<amy::error::client_errors> {
@@ -474,20 +477,24 @@ struct is_error_code_enum<amy::error::misc_errors> {
 
 }; // struct is_error_code_enum
 
+#if defined(USE_BOOST_ASIO)
 } // namespace system
 } // namespace boost
+#else
+} // namespace std
+#endif
 
 namespace amy {
 namespace error {
 
-inline boost::system::error_code make_error_code(client_errors e) {
-    return boost::system::error_code(static_cast<int>(e),
-                                     get_client_category());
+inline AMY_SYSTEM_NS::error_code make_error_code(client_errors e) {
+    return AMY_SYSTEM_NS::error_code(static_cast<int>(e),
+                                      get_client_category());
 }
 
-inline boost::system::error_code make_error_code(misc_errors e) {
-    return boost::system::error_code(static_cast<int>(e),
-                                     get_misc_category());
+inline AMY_SYSTEM_NS::error_code make_error_code(misc_errors e) {
+    return AMY_SYSTEM_NS::error_code(static_cast<int>(e),
+                                      get_misc_category());
 }
 
 } // namespace error

--- a/include/amy/execute.hpp
+++ b/include/amy/execute.hpp
@@ -12,7 +12,7 @@ template<typename MySQLService>
 uint64_t execute(basic_connector<MySQLService>& connector,
                  std::string const& stmt)
 {
-    boost::system::error_code ec;
+    AMY_SYSTEM_NS::error_code ec;
     uint64_t affected_rows = execute(connector, stmt, ec);
     detail::throw_error(ec, connector.native());
     return affected_rows;
@@ -21,7 +21,7 @@ uint64_t execute(basic_connector<MySQLService>& connector,
 template<typename MySQLService>
 uint64_t execute(basic_connector<MySQLService>& connector,
                  std::string const& stmt,
-                 boost::system::error_code& ec)
+                 AMY_SYSTEM_NS::error_code& ec)
 {
     connector.query(stmt, ec);
     if (ec) {

--- a/include/amy/impl/mysql_service.ipp
+++ b/include/amy/impl/mysql_service.ipp
@@ -9,11 +9,11 @@
 
 namespace amy {
 
-inline mysql_service::mysql_service(boost::asio::io_service& io_service) :
+inline mysql_service::mysql_service(AMY_ASIO_NS::io_service& io_service) :
     detail::service_base<mysql_service>(io_service),
     work_mutex_(),
-    work_io_service_(new boost::asio::io_service),
-    work_(new boost::asio::io_service::work(*work_io_service_)),
+    work_io_service_(new AMY_ASIO_NS::io_service),
+    work_(new AMY_ASIO_NS::io_service::work(*work_io_service_)),
     work_thread_()
 {}
 
@@ -50,7 +50,7 @@ mysql_service::native(implementation_type& impl) {
 
 inline std::string
 mysql_service::error_message(implementation_type& impl,
-                             boost::system::error_code const& ec)
+                             AMY_SYSTEM_NS::error_code const& ec)
 {
     uint32_t ev = static_cast<uint32_t>(ec.value());
 
@@ -61,8 +61,8 @@ mysql_service::error_message(implementation_type& impl,
     }
 }
 
-inline boost::system::error_code
-mysql_service::open(implementation_type& impl, boost::system::error_code& ec) {
+inline AMY_SYSTEM_NS::error_code
+mysql_service::open(implementation_type& impl, AMY_SYSTEM_NS::error_code& ec) {
     namespace ops = amy::detail::mysql_ops;
 
     ops::clear_error(ec);
@@ -87,25 +87,25 @@ inline void mysql_service::close(implementation_type& impl) {
 inline void mysql_service::start_work_thread() {
     std::lock_guard<std::mutex> lock(work_mutex_);
 
-    typedef size_t(boost::asio::io_service::*run_function)();
+    typedef size_t(AMY_ASIO_NS::io_service::*run_function)();
 
     if (!work_thread_) {
         work_thread_.reset(
                 new std::thread(
                     std::bind<run_function>(
-                        &boost::asio::io_service::run,
+                        &AMY_ASIO_NS::io_service::run,
                         work_io_service_.get())));
     }
 }
 
 template<typename Endpoint>
-boost::system::error_code
+AMY_SYSTEM_NS::error_code
 mysql_service::connect(implementation_type& impl,
                        Endpoint const& endpoint,
                        auth_info const& auth,
                        std::string const& database,
                        client_flags client_flag,
-                       boost::system::error_code& ec)
+                       AMY_SYSTEM_NS::error_code& ec)
 {
     if (!is_open(impl)) {
         if (open(impl, ec)) {
@@ -135,7 +135,7 @@ void mysql_service::async_connect(implementation_type& impl,
                                   ConnectHandler handler)
 {
     if (!is_open(impl)) {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         if (!!open(impl, ec)) {
             this->get_io_service().post(std::bind(handler, ec));
             return;
@@ -151,10 +151,10 @@ void mysql_service::async_connect(implementation_type& impl,
     }
 }
 
-inline boost::system::error_code
+inline AMY_SYSTEM_NS::error_code
 mysql_service::query(implementation_type& impl,
                      std::string const& stmt,
-                     boost::system::error_code& ec)
+                     AMY_SYSTEM_NS::error_code& ec)
 {
     if (!is_open(impl)) {
         ec = amy::error::not_initialized;
@@ -206,7 +206,7 @@ mysql_service::has_more_results(implementation_type const& impl) const {
 }
 
 inline result_set mysql_service::store_result(implementation_type& impl,
-                                              boost::system::error_code& ec)
+                                              AMY_SYSTEM_NS::error_code& ec)
 {
     namespace ops = amy::detail::mysql_ops;
 
@@ -257,19 +257,19 @@ void mysql_service::async_store_result(implementation_type& impl,
     }
 }
 
-inline boost::system::error_code
+inline AMY_SYSTEM_NS::error_code
 mysql_service::autocommit(implementation_type& impl,
                           bool mode,
-                          boost::system::error_code& ec)
+                          AMY_SYSTEM_NS::error_code& ec)
 {
     namespace ops = amy::detail::mysql_ops;
     ops::mysql_autocommit(&impl.mysql, mode, ec);
     return ec;
 }
 
-inline boost::system::error_code
+inline AMY_SYSTEM_NS::error_code
 mysql_service::commit(implementation_type& impl,
-                      boost::system::error_code& ec)
+                      AMY_SYSTEM_NS::error_code& ec)
 {
     namespace ops = amy::detail::mysql_ops;
 
@@ -282,9 +282,9 @@ mysql_service::commit(implementation_type& impl,
     return ec;
 }
 
-inline boost::system::error_code
+inline AMY_SYSTEM_NS::error_code
 mysql_service::rollback(implementation_type& impl,
-                        boost::system::error_code& ec)
+                        AMY_SYSTEM_NS::error_code& ec)
 {
     namespace ops = amy::detail::mysql_ops;
 
@@ -333,10 +333,10 @@ inline void mysql_service::implementation::close() {
 }
 
 template<typename Option>
-boost::system::error_code
+AMY_SYSTEM_NS::error_code
 mysql_service::set_option(implementation_type& impl,
                           Option const& option,
-                          boost::system::error_code& ec)
+                          AMY_SYSTEM_NS::error_code& ec)
 {
     namespace ops = detail::mysql_ops;
 
@@ -363,7 +363,7 @@ inline void mysql_service::implementation::cancel() {
 template<typename Handler>
 mysql_service::handler_base<Handler>::handler_base(
         implementation_type& impl,
-        boost::asio::io_service& io_service,
+        AMY_ASIO_NS::io_service& io_service,
         Handler handler)
   : impl_(impl),
     cancelation_token_(impl.cancelation_token),
@@ -379,7 +379,7 @@ mysql_service::connect_handler<Endpoint, ConnectHandler>::connect_handler(
         amy::auth_info const& auth,
         std::string const& database,
         client_flags flags,
-        boost::asio::io_service& io_service,
+        AMY_ASIO_NS::io_service& io_service,
         ConnectHandler handler)
   : handler_base<ConnectHandler>(impl, io_service, handler),
     endpoint_(endpoint),
@@ -396,13 +396,13 @@ void mysql_service::connect_handler<Endpoint, ConnectHandler>::operator()() {
     if (this->cancelation_token_.expired()) {
         this->io_service_.post(
                 std::bind(this->handler_,
-                          boost::asio::error::operation_aborted));
+                          AMY_ASIO_NS::error::operation_aborted));
         return;
     }
 
     amy::endpoint_traits<Endpoint> traits(this->endpoint_);
 
-    boost::system::error_code ec;
+    AMY_SYSTEM_NS::error_code ec;
     ops::mysql_real_connect(&this->impl_.mysql,
                             traits.host(),
                             auth_.user(),
@@ -421,7 +421,7 @@ template<typename QueryHandler>
 mysql_service::query_handler<QueryHandler>::query_handler(
         implementation_type& impl,
         std::string const& stmt,
-        boost::asio::io_service& io_service,
+        AMY_ASIO_NS::io_service& io_service,
         QueryHandler handler)
   : handler_base<QueryHandler>(impl, io_service, handler),
     stmt_(stmt)
@@ -435,14 +435,14 @@ void mysql_service::query_handler<QueryHandler>::operator()() {
     if (this->cancelation_token_.expired()) {
         this->io_service_.post(
                 std::bind(this->handler_,
-                          boost::asio::error::operation_aborted));
+                          AMY_ASIO_NS::error::operation_aborted));
         return;
     }
 
     this->impl_.free_result();
     this->impl_.first_result_stored = false;
 
-    boost::system::error_code ec;
+    AMY_SYSTEM_NS::error_code ec;
     ops::mysql_real_query(&this->impl_.mysql,
                           stmt_.c_str(),
                           stmt_.length(),
@@ -454,7 +454,7 @@ void mysql_service::query_handler<QueryHandler>::operator()() {
 template<typename StoreResultHandler>
 mysql_service::store_result_handler<StoreResultHandler>::store_result_handler(
         implementation_type& impl,
-        boost::asio::io_service& io_service,
+        AMY_ASIO_NS::io_service& io_service,
         StoreResultHandler handler)
   : handler_base<StoreResultHandler>(impl, io_service, handler)
 {}
@@ -466,19 +466,19 @@ void mysql_service::store_result_handler<StoreResultHandler>::operator()() {
     if (this->cancelation_token_.expired()) {
         this->io_service_.post(
                 std::bind(this->handler_,
-                          boost::asio::error::operation_aborted,
+                          AMY_ASIO_NS::error::operation_aborted,
                           result_set::empty_set(&this->impl_.mysql)));
         return;
     }
 
-    boost::system::error_code ec;
+    AMY_SYSTEM_NS::error_code ec;
 
     if (this->impl_.first_result_stored) {
         // Frees the last result set.
         this->impl_.free_result();
 
         mysql_service& service =
-            boost::asio::use_service<mysql_service>(this->io_service_);
+            AMY_ASIO_NS::use_service<mysql_service>(this->io_service_);
 
         if (!service.has_more_results(this->impl_)) {
             ec = amy::error::no_more_results;

--- a/include/amy/mysql_service.hpp
+++ b/include/amy/mysql_service.hpp
@@ -33,7 +33,7 @@ public:
 
     typedef detail::mysql_handle native_type;
 
-    explicit mysql_service(boost::asio::io_service& io_service);
+    explicit mysql_service(AMY_ASIO_NS::io_service& io_service);
 
     ~mysql_service();
 
@@ -46,29 +46,29 @@ public:
     native_type native(implementation_type& impl);
 
     std::string error_message(implementation_type& impl,
-                              boost::system::error_code const& ec);
+                              AMY_SYSTEM_NS::error_code const& ec);
 
-    boost::system::error_code open(implementation_type& impl,
-                                   boost::system::error_code& ec);
+    AMY_SYSTEM_NS::error_code open(implementation_type& impl,
+                                   AMY_SYSTEM_NS::error_code& ec);
 
     bool is_open(implementation_type const& impl) const;
 
     void close(implementation_type& impl);
 
     template<typename Option>
-    boost::system::error_code set_option(implementation_type& impl,
+    AMY_SYSTEM_NS::error_code set_option(implementation_type& impl,
                                          Option const& option,
-                                         boost::system::error_code& ec);
+                                         AMY_SYSTEM_NS::error_code& ec);
 
     void cancel(implementation_type& impl);
 
     template<typename Endpoint>
-    boost::system::error_code connect(implementation_type& impl,
+    AMY_SYSTEM_NS::error_code connect(implementation_type& impl,
                                       Endpoint const& endpoint,
                                       auth_info const& auth,
                                       std::string const& database,
                                       client_flags client_flag,
-                                      boost::system::error_code& ec);
+                                      AMY_SYSTEM_NS::error_code& ec);
 
     template<typename Endpoint, typename ConnectHandler>
     void async_connect(implementation_type& impl,
@@ -78,9 +78,9 @@ public:
                        client_flags flags,
                        ConnectHandler handler);
 
-    boost::system::error_code query(implementation_type& impl,
+    AMY_SYSTEM_NS::error_code query(implementation_type& impl,
                                     std::string const& stmt,
-                                    boost::system::error_code& ec);
+                                    AMY_SYSTEM_NS::error_code& ec);
 
     template<typename QueryHandler>
     void async_query(implementation_type& impl,
@@ -90,21 +90,21 @@ public:
     bool has_more_results(implementation_type const& impl) const;
 
     result_set store_result(implementation_type& impl,
-                            boost::system::error_code& ec);
+                            AMY_SYSTEM_NS::error_code& ec);
 
     template<typename StoreResultHandler>
     void async_store_result(implementation_type& impl,
                             StoreResultHandler handler);
 
-    boost::system::error_code autocommit(implementation_type& impl,
+    AMY_SYSTEM_NS::error_code autocommit(implementation_type& impl,
                                          bool mode,
-                                         boost::system::error_code& ec);
+                                         AMY_SYSTEM_NS::error_code& ec);
 
-    boost::system::error_code commit(implementation_type& impl,
-                                     boost::system::error_code& ec);
+    AMY_SYSTEM_NS::error_code commit(implementation_type& impl,
+                                     AMY_SYSTEM_NS::error_code& ec);
 
-    boost::system::error_code rollback(implementation_type& impl,
-                                       boost::system::error_code& ec);
+    AMY_SYSTEM_NS::error_code rollback(implementation_type& impl,
+                                       AMY_SYSTEM_NS::error_code& ec);
 
     uint64_t affected_rows(implementation_type& impl);
 
@@ -113,8 +113,8 @@ private:
 
     detail::mysql_lib_init mysql_lib_init_;
     std::mutex work_mutex_;
-    std::unique_ptr<boost::asio::io_service> work_io_service_;
-    std::unique_ptr<boost::asio::io_service::work> work_;
+    std::unique_ptr<AMY_ASIO_NS::io_service> work_io_service_;
+    std::unique_ptr<AMY_ASIO_NS::io_service::work> work_;
     std::unique_ptr<std::thread> work_thread_;
 
     void start_work_thread();
@@ -170,14 +170,14 @@ template<typename Handler>
 class mysql_service::handler_base {
 public:
     explicit handler_base(implementation_type& impl,
-                          boost::asio::io_service& io_service,
+                          AMY_ASIO_NS::io_service& io_service,
                           Handler handler);
 
 protected:
     implementation_type& impl_;
     std::weak_ptr<void> cancelation_token_;
-    boost::asio::io_service& io_service_;
-    boost::asio::io_service::work work_;
+    AMY_ASIO_NS::io_service& io_service_;
+    AMY_ASIO_NS::io_service::work work_;
     Handler handler_;
 
 }; // class mysql_service::handler_base
@@ -190,7 +190,7 @@ public:
                              amy::auth_info const& auth,
                              std::string const& database,
                              client_flags flags,
-                             boost::asio::io_service& io_service,
+                             AMY_ASIO_NS::io_service& io_service,
                              ConnectHandler handler);
 
     void operator()();
@@ -208,7 +208,7 @@ class mysql_service::query_handler : public handler_base<QueryHandler> {
 public:
     explicit query_handler(implementation_type& impl,
                            std::string const& stmt,
-                           boost::asio::io_service& io_service,
+                           AMY_ASIO_NS::io_service& io_service,
                            QueryHandler handler);
 
     void operator()();
@@ -224,7 +224,7 @@ class mysql_service::store_result_handler :
 {
 public:
     explicit store_result_handler(implementation_type& impl,
-                                  boost::asio::io_service& io_service,
+                                  AMY_ASIO_NS::io_service& io_service,
                                   StoreResultHandler handler);
 
     void operator()();

--- a/include/amy/placeholders.hpp
+++ b/include/amy/placeholders.hpp
@@ -1,7 +1,7 @@
 #ifndef __AMY_PLACEHOLDERS_HPP__
 #define __AMY_PLACEHOLDERS_HPP__
 
-#include <boost/asio/placeholders.hpp>
+#include <amy/asio.hpp>
 
 #include <type_traits>
 

--- a/include/amy/result_set.hpp
+++ b/include/amy/result_set.hpp
@@ -73,15 +73,15 @@ public:
     void assign(native_mysql_type mysql,
                 std::shared_ptr<detail::result_set_type> rs)
     {
-        boost::system::error_code ec;
+        AMY_SYSTEM_NS::error_code ec;
         assign(mysql, rs, ec);
         detail::throw_error(ec, mysql);
     }
 
-    boost::system::error_code
-    assign(native_mysql_type mysql,
-           std::shared_ptr<detail::result_set_type> rs,
-           boost::system::error_code& ec )
+    AMY_SYSTEM_NS::error_code assign(
+            native_mysql_type mysql,
+            std::shared_ptr<detail::result_set_type> rs,
+            AMY_SYSTEM_NS::error_code& ec )
     {
         namespace ops = amy::detail::mysql_ops;
 

--- a/include/amy/system_error.hpp
+++ b/include/amy/system_error.hpp
@@ -1,19 +1,19 @@
 #ifndef __AMY_SYSTEM_ERROR_HPP__
 #define __AMY_SYSTEM_ERROR_HPP__
 
-#include <boost/system/system_error.hpp>
+#include <amy/asio.hpp>
 
 namespace amy {
 
-class system_error : public boost::system::system_error {
+class system_error : public AMY_SYSTEM_NS::system_error {
 public:
-    explicit system_error(boost::system::error_code const& ec) :
-        boost::system::system_error(ec)
+    explicit system_error(AMY_SYSTEM_NS::error_code const& ec) :
+        AMY_SYSTEM_NS::system_error(ec)
     {}
 
-    explicit system_error(boost::system::error_code const& ec,
-                          std::string const& message)
-      : boost::system::system_error(ec),
+    explicit system_error(AMY_SYSTEM_NS::error_code const& ec,
+                          std::string const& message) :
+        AMY_SYSTEM_NS::system_error(ec),
         message_(message)
     {}
 

--- a/test/async_connect_test.cpp
+++ b/test/async_connect_test.cpp
@@ -10,7 +10,7 @@ struct async_connect_test {
         handler_invoked = false;
     }
 
-    void handle_connect(boost::system::error_code const& ec) {
+    void handle_connect(AMY_SYSTEM_NS::error_code const& ec) {
         handler_invoked = true;
     }
 
@@ -19,7 +19,7 @@ struct async_connect_test {
 BOOST_AUTO_TEST_CASE(should_async_connect_to_localhost_with_given_auth_info) {
     async_connect_test fixture;
 
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector c(io_service);
 
     c.async_connect(amy::null_endpoint(),

--- a/test/blocking_connect_test.cpp
+++ b/test/blocking_connect_test.cpp
@@ -3,7 +3,7 @@
 #include <amy/connector.hpp>
 
 BOOST_AUTO_TEST_CASE(should_connect_to_localhost_with_given_auth_info) {
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector c(io_service);
 
     c.connect(amy::null_endpoint(),

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -5,12 +5,12 @@
 #include <amy/connector.hpp>
 
 BOOST_AUTO_TEST_CASE(should_construct_a_connector_instance) {
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 }
 
 BOOST_AUTO_TEST_CASE(should_be_opened_successfully) {
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.open();
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_CASE(should_be_opened_successfully) {
 }
 
 BOOST_AUTO_TEST_CASE(should_be_closed_successfully) {
-    boost::asio::io_service io_service;
+    AMY_ASIO_NS::io_service io_service;
     amy::connector connector(io_service);
 
     connector.open();


### PR DESCRIPTION
This PR tries to fix #1 by adding a compilation flag `USE_BOOST_ASIO` to allow users to choose between Boost.Asio and vanilla (header-only) Asio.

This is achieved by including different set of header files and using different namespaces (`boost::asio`/`boost::system` or `asio`/`std`) according to whether `USE_BOOST_ASIO` is defined or not.