### PR TITLE
Handling exceptions in async_* examples

### DIFF
--- a/example/async_connect.cpp
+++ b/example/async_connect.cpp
@@ -29,7 +29,13 @@ int main(int argc, char* argv[]) {
                                       amy::placeholders::error,
                                       std::ref(connector)));
 
-    io_service.run();
+    try {
+        io_service.run();
+    } catch (AMY_SYSTEM_NS::system_error const& e) {
+        report_system_error(e);
+    } catch (std::exception const& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
 
     return 0;
 }

--- a/example/async_execute.cpp
+++ b/example/async_execute.cpp
@@ -46,7 +46,13 @@ int main(int argc, char* argv[]) {
                                       amy::placeholders::error,
                                       std::ref(connector)));
 
-    io_service.run();
+    try {
+        io_service.run();
+    } catch (AMY_SYSTEM_NS::system_error const& e) {
+        report_system_error(e);
+    } catch (std::exception const& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
 
     return 0;
 }

--- a/example/async_multi_query.cpp
+++ b/example/async_multi_query.cpp
@@ -70,7 +70,13 @@ int main(int argc, char* argv[]) {
                                       amy::placeholders::error,
                                       std::ref(connector)));
 
-    io_service.run();
+    try {
+        io_service.run();
+    } catch (AMY_SYSTEM_NS::system_error const& e) {
+        report_system_error(e);
+    } catch (std::exception const& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
 
     return 0;
 }

--- a/example/async_single_query.cpp
+++ b/example/async_single_query.cpp
@@ -71,7 +71,13 @@ int main(int argc, char* argv[]) {
                                       amy::placeholders::error,
                                       std::ref(connector)));
 
-    io_service.run();
+    try {
+        io_service.run();
+    } catch (AMY_SYSTEM_NS::system_error const& e) {
+        report_system_error(e);
+    } catch (std::exception const& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+    }
 
     return 0;
 }


### PR DESCRIPTION
This PR addresses #10 by adding proper exception handling in all `async_*` examples.